### PR TITLE
feat(mqtt): allow specifying credentials for MQTT broker

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -14,10 +14,14 @@ services:
 options:
   mqtt_host: ""
   mqtt_port: 1883
+  mqtt_username: ""
+  mqtt_password: ""
   asset_modbus_registers_url: "https://www.victronenergy.com/upload/documents/CCGX-Modbus-TCP-register-list-3.50.xlsx"
   asset_sensor_documentation_url: "https://developers.home-assistant.io/docs/core/entity/sensor/"
 schema:
-  mqtt_host: str
+  mqtt_host: str?
   mqtt_port: int
+  mqtt_username: str?
+  mqtt_password: str?
   asset_modbus_registers_url: str
   asset_sensor_documentation_url: str

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -10,6 +10,12 @@ export MQTT_HOST=${MQTT_HOST:-$(bashio::services mqtt "host")}
 export MQTT_PORT=$(bashio::config 'mqtt_port')
 export MQTT_PORT=${MQTT_PORT:-$(bashio::services mqtt "port")}
 
+export MQTT_USERNAME=$(bashio::config 'mqtt_username')
+export MQTT_USERNAME=${MQTT_USERNAME:-$(bashio::services mqtt "username")}
+
+export MQTT_PASSWORD=$(bashio::config 'mqtt_password')
+export MQTT_PASSWORD=${MQTT_USERNAME:-$(bashio::services mqtt "password")}
+
 export ASSET_MODBUS_REGISTERS_URL=$(bashio::config 'asset_modbus_registers_url')
 export ASSET_SENSOR_DOCUMENTATION_URL=$(bashio::config 'asset_sensor_documentation_url')
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -19,6 +19,8 @@ async def main():
     hass_discovery = HassVictronMqttDiscovery(
         mqtt_host = os.environ['MQTT_HOST'],
         mqtt_port = int(os.environ.get('MQTT_PORT', 1883)),
+        mqtt_username = os.environ.get('MQTT_USERNAME', None),
+        mqtt_password = os.environ.get('MQTT_PASSWORD', None),
         mqtt_prefix = os.environ.get('MQTT_PREFIX', ''),
         registers_path = './assets/modbus-registers.xlsx',
         sensor_documentation_path = './assets/sensor-documentation.html',

--- a/hass_victron_mqtt_discovery/discovery.py
+++ b/hass_victron_mqtt_discovery/discovery.py
@@ -25,6 +25,8 @@ class HassVictronMqttDiscovery:
         mqtt_host='127.0.0.1',
         mqtt_port=1883,
         mqtt_prefix="",
+        mqtt_username=None,
+        mqtt_password=None,
         registers=None,
         registers_path=None,
         sensor_documentation=None,
@@ -34,6 +36,8 @@ class HassVictronMqttDiscovery:
         self.mqtt = None
         self.mqtt_host = mqtt_host
         self.mqtt_port = mqtt_port
+        self.mqtt_username = mqtt_username
+        self.mqtt_password = mqtt_password
         self.mqtt_prefix = mqtt_prefix
 
         self.devices = {}
@@ -45,7 +49,12 @@ class HassVictronMqttDiscovery:
         if self.mqtt is not None:
             raise 'Discovery already started'
 
-        self.mqtt = client = aiomqtt.Client(self.mqtt_host, self.mqtt_port)
+        self.mqtt = client = aiomqtt.Client(
+            hostname=self.mqtt_host,
+            port=self.mqtt_port,
+            username=self.mqtt_username,
+            password=self.mqtt_password
+        )
 
         while self.mqtt is not None:
             try:


### PR DESCRIPTION
This PR adds support for
- Passing along the the credentials for MQTT to `aiomqtt.Client`.
- The `MQTT_USERNAME` and `MQTT_PASSWORD` environment variables.
- Autodiscovery for the `username` and `password` values when using the addon.

Resolves #7 